### PR TITLE
Added python3-compatible commands

### DIFF
--- a/autoload/vim_block_party.vim
+++ b/autoload/vim_block_party.vim
@@ -1,7 +1,7 @@
 function! vim_block_party#around_deep()
     let l:block_party_temp_var = []
 
-python << EOF
+pythonx << EOF
 from vim_textobj_block_party import party
 party.around_deep('l:block_party_temp_var')
 EOF
@@ -17,7 +17,7 @@ endfunction
 function! vim_block_party#around_deep_two_way()
     let l:block_party_temp_var = []
 
-python << EOF
+pythonx << EOF
 from vim_textobj_block_party import party
 party.around_deep('l:block_party_temp_var', two_way=True)
 EOF
@@ -33,7 +33,7 @@ endfunction
 function! vim_block_party#inside_deep()
     let l:block_party_temp_var = []
 
-python << EOF
+pythonx << EOF
 from vim_textobj_block_party import party
 party.inside_deep('l:block_party_temp_var')
 EOF
@@ -49,7 +49,7 @@ endfunction
 function! vim_block_party#around_shallow()
     let l:block_party_temp_var = []
 
-python << EOF
+pythonx << EOF
 from vim_textobj_block_party import party
 party.around_shallow('l:block_party_temp_var')
 EOF
@@ -65,7 +65,7 @@ endfunction
 function! vim_block_party#around_shallow_two_way()
     let l:block_party_temp_var = []
 
-python << EOF
+pythonx << EOF
 from vim_textobj_block_party import party
 party.around_shallow('l:block_party_temp_var', two_way=True)
 EOF
@@ -81,7 +81,7 @@ endfunction
 function! vim_block_party#inside_shallow()
     let l:block_party_temp_var = []
 
-python << EOF
+pythonx << EOF
 from vim_textobj_block_party import party
 party.inside_shallow('l:block_party_temp_var')
 EOF

--- a/ftplugin/python/vim_block_party.vim
+++ b/ftplugin/python/vim_block_party.vim
@@ -4,7 +4,7 @@ endif
 
 
 function! s:SetupBlockParty()
-python << EOF
+pythonx << EOF
 from vim_textobj_block_party import environment
 environment.init()
 EOF


### PR DESCRIPTION
This PR is to address a compatibility issue with the way Vim calls Python 2 and Python 3 commands:

Reference: 
https://github.com/ColinKennedy/vim-textobj-block-party/issues/1