### PR TITLE
Bug fix where str and int were being passed to 'max' function

### DIFF
--- a/pythonx/vim_textobj_block_party/columnwise.py
+++ b/pythonx/vim_textobj_block_party/columnwise.py
@@ -22,7 +22,7 @@ def _add_indent(text, indent=1):
     return text + ('    ' * indent)
 
 
-def find_best_column(lines):
+def find_best_indent(lines):
     '''Find the next line's indentation.
 
     If the next line is the start of Python block then the indentation is

--- a/pythonx/vim_textobj_block_party/party.py
+++ b/pythonx/vim_textobj_block_party/party.py
@@ -45,7 +45,7 @@ def _get_buffer_context(extra_lines=False, search=True, two_way=False, customize
     row -= 1  # Get the current row, as a 0-based value
 
     previous_lines = reversed(lines[:row])
-    column = max(column, columnwise.find_best_column(previous_lines))
+    column = max(column, len(columnwise.find_best_indent(previous_lines)))
 
     boundary = party.get_boundary(
         code,


### PR DESCRIPTION
This should hopefully address [the issue described here](https://github.com/ColinKennedy/vim-textobj-block-party/issues/4).