### PR TITLE
Issues 1 pythonx not supported

### DIFF
--- a/autoload/vim_block_party.vim
+++ b/autoload/vim_block_party.vim
@@ -1,10 +1,17 @@
+" Get a Python version to run with (Vim 8.0+ can just use `pythonx`)
+if get(g:, 'expander_python_version', '2') == '2' && has('python')
+   let g:_uspy=":python "
+elseif get(g:, 'expander_python_version', '3') == '3' && has('python3')
+   let g:_uspy=":python3 "
+else
+    echoerr "No matching Python version could be found"
+endif
+
+
 function! vim_block_party#around_deep()
     let l:block_party_temp_var = []
 
-pythonx << EOF
-from vim_textobj_block_party import party
-party.around_deep('l:block_party_temp_var')
-EOF
+    execute g:_uspy "from vim_textobj_block_party import party;party.around_deep('l:block_party_temp_var')"
 
     if l:block_party_temp_var == []
         return 0
@@ -17,10 +24,7 @@ endfunction
 function! vim_block_party#around_deep_two_way()
     let l:block_party_temp_var = []
 
-pythonx << EOF
-from vim_textobj_block_party import party
-party.around_deep('l:block_party_temp_var', two_way=True)
-EOF
+    execute g:_uspy "from vim_textobj_block_party import party;party.around_deep('l:block_party_temp_var', two_way=True)"
 
     if l:block_party_temp_var == []
         return 0
@@ -33,10 +37,7 @@ endfunction
 function! vim_block_party#inside_deep()
     let l:block_party_temp_var = []
 
-pythonx << EOF
-from vim_textobj_block_party import party
-party.inside_deep('l:block_party_temp_var')
-EOF
+    execute g:_uspy "from vim_textobj_block_party import party;party.inside_deep('l:block_party_temp_var')"
 
     if l:block_party_temp_var == []
         return 0
@@ -49,10 +50,7 @@ endfunction
 function! vim_block_party#around_shallow()
     let l:block_party_temp_var = []
 
-pythonx << EOF
-from vim_textobj_block_party import party
-party.around_shallow('l:block_party_temp_var')
-EOF
+    execute g:_uspy "from vim_textobj_block_party import party;party.around_shallow('l:block_party_temp_var')"
 
     if len(l:block_party_temp_var) == 0
         return 0
@@ -65,10 +63,7 @@ endfunction
 function! vim_block_party#around_shallow_two_way()
     let l:block_party_temp_var = []
 
-pythonx << EOF
-from vim_textobj_block_party import party
-party.around_shallow('l:block_party_temp_var', two_way=True)
-EOF
+    execute g:_uspy "from vim_textobj_block_party import party;party.around_shallow('l:block_party_temp_var', two_way=True)"
 
     if l:block_party_temp_var == []
         return 0
@@ -81,10 +76,7 @@ endfunction
 function! vim_block_party#inside_shallow()
     let l:block_party_temp_var = []
 
-pythonx << EOF
-from vim_textobj_block_party import party
-party.inside_shallow('l:block_party_temp_var')
-EOF
+    execute g:_uspy "from vim_textobj_block_party import party;party.inside_shallow('l:block_party_temp_var')"
 
     if l:block_party_temp_var == []
         return 0

--- a/ftplugin/python/vim_block_party.vim
+++ b/ftplugin/python/vim_block_party.vim
@@ -19,8 +19,6 @@ endif
 
 
 function! s:SetupBlockParty()
-    " from vim_textobj_block_party import environment
-    " environment.init()
     execute g:_uspy "from vim_textobj_block_party import environment;environment.init()"
 endfunction
 

--- a/ftplugin/python/vim_block_party.vim
+++ b/ftplugin/python/vim_block_party.vim
@@ -1,13 +1,27 @@
+if !has('python') && !has('python3')
+    echoerr "vim-python-function-expander requires Python. Cannot continue loading this plugin"
+    finish
+endif
+
 if get(g:, 'block_party_loaded', '0') == '1'
     finish
 endif
 
 
+" Get a Python version to run with (Vim 8.0+ can just use `pythonx`)
+if get(g:, 'expander_python_version', '2') == '2' && has('python')
+   let g:_uspy=":python "
+elseif get(g:, 'expander_python_version', '3') == '3' && has('python3')
+   let g:_uspy=":python3 "
+else
+    echoerr "No matching Python version could be found"
+endif
+
+
 function! s:SetupBlockParty()
-pythonx << EOF
-from vim_textobj_block_party import environment
-environment.init()
-EOF
+    " from vim_textobj_block_party import environment
+    " environment.init()
+    execute g:_uspy "from vim_textobj_block_party import environment;environment.init()"
 endfunction
 
 

--- a/pythonx/vim_textobj_block_party/block_party/party.py
+++ b/pythonx/vim_textobj_block_party/block_party/party.py
@@ -18,9 +18,12 @@ try:
     from parso.python import tree
     import parso
 except ImportError:
-    # Use the provided parso library if the user doesn't have it installed.
-    from .vendors.parso.python import tree
-    from .vendors import parso
+    import sys
+    import os
+    from . import vendors
+    sys.path.append(os.path.dirname(vendors.__file__))
+    from parso.python import tree
+    import parso
 
 # IMPORT LOCAL LIBRARIES
 from . import config


### PR DESCRIPTION
The aim of this PR is to make vim-textobj-block-party work with older Vim versions and neovim, which both do not support the `pythonx` command.

Also, there was a parso import error that should hopefully also be fixed.